### PR TITLE
Force hotfixed version of SeisSolXDMF

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -53,9 +53,9 @@ version = "1.3.0"
 
 [[Compat]]
 deps = ["Base64", "Dates", "DelimitedFiles", "Distributed", "InteractiveUtils", "LibGit2", "Libdl", "LinearAlgebra", "Markdown", "Mmap", "Pkg", "Printf", "REPL", "Random", "SHA", "Serialization", "SharedArrays", "Sockets", "SparseArrays", "Statistics", "Test", "UUIDs", "Unicode"]
-git-tree-sha1 = "79b9563ef3f2cc5fc6d3046a5ee1a57c9de52495"
+git-tree-sha1 = "727e463cfebd0c7b999bbf3e9e7e16f254b94193"
 uuid = "34da2185-b29b-5c13-b0c7-acf172513d20"
-version = "3.33.0"
+version = "3.34.0"
 
 [[Dates]]
 deps = ["Printf"]
@@ -220,9 +220,9 @@ uuid = "ca575930-c2e3-43a9-ace4-1e988b2c1908"
 
 [[OffsetArrays]]
 deps = ["Adapt"]
-git-tree-sha1 = "c0f4a4836e5f3e0763243b8324200af6d0e0f90c"
+git-tree-sha1 = "c870a0d713b51e4b49be6432eff0e26a4325afee"
 uuid = "6fe1bfb0-de20-5000-8ca7-80f57d26f881"
-version = "1.10.5"
+version = "1.10.6"
 
 [[OpenSSL_jll]]
 deps = ["Artifacts", "JLLWrappers", "Libdl", "Pkg"]
@@ -264,9 +264,9 @@ uuid = "c84ed2f1-dad5-54f0-aa8e-dbefe2724439"
 version = "0.4.1"
 
 [[Reexport]]
-git-tree-sha1 = "5f6c21241f0f655da3952fd60aa18477cf96c220"
+git-tree-sha1 = "45e428421666073eab6f2da5c9d310d99bb12f9b"
 uuid = "189a3867-3050-52da-a836-e630ba90ab69"
-version = "1.1.0"
+version = "1.2.2"
 
 [[Requires]]
 deps = ["UUIDs"]
@@ -278,10 +278,10 @@ version = "1.1.3"
 uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
 
 [[SeisSolXDMF]]
-deps = ["HDF5", "XMLDict"]
-git-tree-sha1 = "4ea4721065a3e4596b048c1095e82a961615dc63"
+deps = ["HDF5", "Pkg", "Test", "XMLDict"]
+git-tree-sha1 = "3c72c1c15263a52efefec7cb6ba3cd69690b3ed1"
 uuid = "fc3049fc-4624-4ea9-a8a9-22daae44174f"
-version = "1.0.0"
+version = "1.0.1"
 
 [[Serialization]]
 uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"

--- a/Project.toml
+++ b/Project.toml
@@ -16,3 +16,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 julia = "^1.4"
+SeisSolXDMF = "^1.0.1"

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Once you have installed SAMPLER and you have the SeisSol outputs in XDMF format 
 ```bash
 cd path/to/sampler/
 export JULIA_NUM_THREADS=<num_threads>
-julia --project=. src/main.jl <options>
+julia --project src/main.jl <options>
 ```
 
 _Note: In Windows (PowerShell), replace `export ...` with:_
@@ -50,7 +50,7 @@ $env:JULIA_NUM_THREADS = <num_threads>
 _Note: For an explanation of the available command line options, type:_
 
 ```bash
-julia --project=. src/main.jl --help
+julia --project src/main.jl --help
 ```
 
 You can also have a look at the `run_sampler.sh` and `run_kajiura.sh` scripts to see how SAMPLER can be executed on the LRZ compute clusters.
@@ -68,7 +68,7 @@ _Note: Kajiura's Filter needs to process all timesteps prior to `timestep_end`._
 ### Basic example: Rasterize 2D grids (seafloor and sea surface data is available)
 
 ```bash
-julia --project=. src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc ~/seissol-outputs/out-surface.xdmf
+julia --project src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc ~/seissol-outputs/out-surface.xdmf
 ```
 
 Only rasterizes the 2D surface outputs (seafloor and sea surface elevation).
@@ -76,13 +76,13 @@ Only rasterizes the 2D surface outputs (seafloor and sea surface elevation).
 ### Rasterize only seafloor (and optionally apply Kajiura's Filter)
 
 ```bash
-julia --project=. src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc --seafloor-only ~/seissol-outputs/out-surface.xdmf
+julia --project src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc --seafloor-only ~/seissol-outputs/out-surface.xdmf
 ```
 
 Only rasterizes the 2D _seafloor_ elevation over time. Optionally thereafter:
 
 ```bash    
-julia --project=. src/main.jl ~/sampler-output.nc ~/kajiura-output.nc 300
+julia --project src/main.jl ~/sampler-output.nc ~/kajiura-output.nc 300
 ```
 
 Applies Kajiura's Filter for 300 timesteps.
@@ -92,7 +92,7 @@ _Note: You can also rasterize the SeisSol outputs fully (without `--seafloor-onl
 ### Rasterize seafloor using Tanioka's method
 
 ```bash
-julia --project=. src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc --seafloor-only --tanioka ~/seissol-outputs/out-surface.xdmf
+julia --project src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc --seafloor-only --tanioka ~/seissol-outputs/out-surface.xdmf
 ```
 
 Applies Tanioka's method while rasterizing the seafloor. Needed if bathymetry is not flat.
@@ -102,7 +102,7 @@ _Note: You can also use Tanioka's method when rasterizing more than just the sea
 ### Rasterize fully (with 3D velocity grid)
 
 ```bash
-julia --project=. src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc -s 300 ~/seissol-outputs/out-surface.xdmf
+julia --project src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc -s 300 ~/seissol-outputs/out-surface.xdmf
 ```
 
 Rasterizes all grids and variables needed for tsunami simulation, including the 3D velocity grid.

--- a/run_kajiura.sh
+++ b/run_kajiura.sh
@@ -3,12 +3,11 @@
 #SBATCH -o ./kaji-run.%x.%j.%N.out
 #SBATCH -D ./
 #SBATCH --get-user-env
-#SBATCH --clusters=cm2_tiny
-#SBATCH --partition=cm2_tiny
 #SBATCH --nodes=1-1
 #SBATCH --cpus-per-task=28
 #SBATCH --export=NONE
 #SBATCH --time=02:00:00
+# TODO: Specify cluster / account / mail settings / etc.
 module load slurm_setup
 export JULIA_NUM_THREADS=56
 echo "Starting Kajiura with $JULIA_NUM_THREADS threads:"

--- a/run_sampler.sh
+++ b/run_sampler.sh
@@ -5,19 +5,12 @@
 #SBATCH -D ./
 #SBATCH --get-user-env
 #SBATCH --partition=micro
-#SBATCH --account=pr63qo
 #SBATCH --nodes=1
 #SBATCH --export=NONE
-#SBATCH --mail-type=ALL
-#SBATCH --mail-user=m.schmeller@tum.de
 #SBATCH --time=00:30:00
+# TODO: Specify cluster / account / mail settings / etc.
 module load slurm_setup
 . ~/.bashrc
-
-# exit when any command fails
-set -e
-# echo an error message before exiting
-trap 'echo "\"${last_command}\" command filed with exit code $?."' EXIT
 
 export JULIA_NUM_THREADS=48
 date
@@ -29,9 +22,10 @@ mkdir -p $DSTDIR
 echo "=== Working on $SRCDIR"
 
 echo "=== Starting SAMPLER with $JULIA_NUM_THREADS threads:"
+# Just exmaples, replace or leave out.
 fvars="U=>fU,V=>fV,W=>fW,u=>fu,v=>fv,w=>fw"
 svars="U=>sU,V=>sV,W=>sW,u=>su,v=>sv,w=>sw"
 
-julia --project=. ./src/SAMPLER.jl --water-height=2000 --seafloor-vars $fvars --surface-vars $svars -m 25G -o "$DSTDIR/rasterized.nc" "$SRCDIR/${OUTNAME}.xdmf"
+julia --project=. ./src/main.jl --water-height=2000 --seafloor-vars $fvars --surface-vars $svars -m 25G -o "$DSTDIR/rasterized.nc" "$SRCDIR/${OUTNAME}.xdmf"
 date
 echo "=== Complete."


### PR DESCRIPTION
SeisSolXDMF v1.0.0 could not handle SeisSol POSIX outputs correctly so this PR forces the new version v1.0.1 via its project files.