### PR TITLE
Change required Julia version to 1.6

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,5 +15,5 @@ SeisSolXDMF = "fc3049fc-4624-4ea9-a8a9-22daae44174f"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-julia = "^1.4"
+julia = "^1.6"
 SeisSolXDMF = "^1.0.1"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SAMPLER is a program for rasterizing unstructured meshes output by [SeisSol][1] 
 Additionally, it offers postprocessing options, namely depth filtering via [Kajiura's filter][3] and converting horizontal displacements to vertical ones using [Tanioka's method][7].
 
 ## Installation
-First, set up Julia on your machine.
+First, set up Julia (**v1.6 or greater**) on your machine.
 The recommended ways are:
 
 * On SuperMUC-NG: [Julia on SuperMUC-NG and HPC Systems, Getting Started][8]


### PR DESCRIPTION
Julia 1.4 apparently has a different format for package versions in its Pkg package manager.
Thus, installation of SAMPLER fails.
1.6 fixes this Issue.

Fixes #8 