### PR TITLE
Thomas/kajiura filter nofft

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ More help for running on the cluster can be found [here][5].
 Once you have rasterized the SeisSol output files, you can optionally use Kajiura's filter on the outputs:
 
 ```bash
-julia --project scripts/kajiura.jl <in_file.nc> <out_file.nc> <timestep_end>
+julia --project scripts/kajiura.jl <in_file.nc> <out_file.nc> <timestep_end> <filter_depth (0: variable, slower code)>
 ```
 
 _Note: Kajiura's Filter needs to process all timesteps prior to `timestep_end`._
@@ -82,7 +82,7 @@ julia --project src/main.jl -m 8G --water-height=2000 -o ~/sampler-output.nc --s
 Only rasterizes the 2D _seafloor_ elevation over time. Optionally thereafter:
 
 ```bash    
-julia --project src/main.jl ~/sampler-output.nc ~/kajiura-output.nc 300
+julia --project src/main.jl ~/sampler-output.nc ~/kajiura-output.nc 300 0.
 ```
 
 Applies Kajiura's Filter for 300 timesteps.

--- a/scripts/kajiura.jl
+++ b/scripts/kajiura.jl
@@ -97,9 +97,10 @@ function apply_kajiura!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float64, 
     Threads.@threads for x ∈ 1:nx
         for y ∈ 1:ny
             h_yx = max(0., water_level - b[y, x]) # height 0 on land
-            if (h_yx> 10.0 ) && (abs(d[y, x]) > 1e-8)
-                filter_nx_half = ceil(Int, n_h * h_max / Δx / 2)
-                filter_ny_half = ceil(Int, n_h * h_max / Δy / 2)
+            if (h_yx> 0.01 ) && (abs(d[y, x]) > 1e-8)
+                # the min is required to avoid aritacts at very shallow depth
+                filter_nx_half = min(3, ceil(Int, n_h * h_max / Δx / 2))
+                filter_ny_half = min(3, ceil(Int, n_h * h_max / Δy / 2))
 
                 xmin = max(1, x-filter_nx_half)
                 xmax = min(nx, x+filter_nx_half)

--- a/scripts/kajiura.jl
+++ b/scripts/kajiura.jl
@@ -35,7 +35,7 @@ const G = begin
 end
 
 function precalculate_σ(h_min :: Float64, h_max :: Float64, Δx :: Float64, Δy :: Float64; n_h :: Float64 = 20.)
-    Δh = (h_max - h_min) / 10
+    Δh = (h_max - max(0.0, h_min)) / 10
     if Δh == 0.; Δh = 1.; end
     l_h = max(0.0001, h_min):Δh:(h_max + Δh)
 
@@ -88,11 +88,42 @@ function apply_kajiura!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float64, 
                 h_min :: Float64, h_max :: Float64, Δx :: Float64, Δy :: Float64; water_level :: Float64 = 0., n_h :: Float64 = 20., 
                 σ = precalculate_σ(h_min, h_max, Δx, Δy; n_h=n_h))
     
-    filter_nx_half = ceil(Int, n_h * h_max / Δx / 2)
-    filter_ny_half = ceil(Int, n_h * h_max / Δy / 2)
-
     nx = size(η, 2)
     ny = size(η, 1)
+    filter_nx_half0 = ceil(Int, n_h * h_max / Δx / 2)
+    filter_ny_half0 = ceil(Int, n_h * h_max / Δy / 2)
+    
+    println("  Computing displacement matrix...")
+    Threads.@threads for x ∈ 1:nx
+        for y ∈ 1:ny
+            h_yx = max(0., water_level - b[y, x]) # height 0 on land
+            if (h_yx> 10.0 ) && (abs(d[y, x]) > 1e-8)
+                filter_nx_half = ceil(Int, n_h * h_max / Δx / 2)
+                filter_ny_half = ceil(Int, n_h * h_max / Δy / 2)
+
+                xmin = max(1, x-filter_nx_half)
+                xmax = min(nx, x+filter_nx_half)
+
+                ymin = max(1, y-filter_ny_half)
+                ymax = min(ny, y+filter_ny_half)
+
+                filter = zeros(Float64, (ymax-ymin+1, xmax-xmin+1))
+                for x1 ∈ xmin:xmax
+                    for y1 ∈ ymin:ymax
+                        filter[y1-ymin+1,x1-xmin+1] = G(sqrt(((x1-x) * Δx)^2 + ((y1-y) * Δy)^2) / h_yx)
+                    end
+                end
+                η[ymin:ymax, xmin:xmax] +=  σ(h_yx) * Δx * Δy / h_yx^2 * d[y, x] * filter
+            end
+        end
+    end
+end
+
+function compute_filter(h_max :: Float64, Δx :: Float64, Δy :: Float64, nx :: Int64, ny :: Int64,
+                n_h :: Float64)
+
+    filter_nx_half = ceil(Int, n_h * h_max / Δx / 2)
+    filter_ny_half = ceil(Int, n_h * h_max / Δy / 2)
 
     filter = zeros(Float64, (ny, nx))
 
@@ -105,6 +136,17 @@ function apply_kajiura!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float64, 
             filter[((ny + y) % ny) + 1, ((nx + x) % nx) + 1] = G(sqrt((x * Δx)^2 + (y * Δy)^2) / h_max)
         end
     end
+    return filter
+end
+
+function apply_kajiura_fft!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float64, 2}, η::AbstractArray{Float64, 2}, 
+                h_min :: Float64, h_max :: Float64, Δx :: Float64, Δy :: Float64; water_level :: Float64 = 0., n_h :: Float64 = 20., 
+                σ = precalculate_σ(h_min, h_max, Δx, Δy; n_h=n_h))
+    
+    nx = size(η, 2)
+    ny = size(η, 1)
+
+    filter = compute_filter(h_max, Δx, Δy, nx, ny, n_h)
 
     println("  Computing displacement matrix...")
     Threads.@threads for x ∈ 1:size(η, 2)
@@ -191,6 +233,7 @@ function main()
         current_η_diff .= 0.
         current_d_diff .= d[:,:,t] .- current_disp
         apply_kajiura!(b .+ current_disp, current_d_diff, current_η_diff, -maximum(b), -minimum(b), Δx, Δy)
+        #apply_kajiura_fft!(b .+ current_disp, current_d_diff, current_η_diff, -maximum(b), -minimum(b), Δx, Δy)
         current_disp = d[:,:,t]
 
         println("  Writing output for timestep")

--- a/scripts/kajiura.jl
+++ b/scripts/kajiura.jl
@@ -115,6 +115,8 @@ function apply_kajiura!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float64, 
                     end
                 end
                 η[ymin:ymax, xmin:xmax] +=  σ(h_yx) * Δx * Δy / h_yx^2 * d[y, x] * filter
+            else
+                η[y,x] =  d[y, x]
             end
         end
     end
@@ -157,7 +159,7 @@ function apply_kajiura_fft!(b::AbstractArray{Float64, 2}, d::AbstractArray{Float
                 if h_yx != 0.
                     σ(filter_depth) * Δx * Δy / filter_depth^2 * d[y, x]
                 else
-                    0. # No displacement where no water is (Kajiura not applicable)
+                    d[y, x]  # No displacement where no water is (Kajiura not applicable)
                 end
         end
     end

--- a/src/rasterizer/rasterization.jl
+++ b/src/rasterizer/rasterization.jl
@@ -341,9 +341,8 @@ module Rasterization
                     is_bath = is_bathy(m3n_simp_points, ctx.water_height)
 
                     # locationFlag==1 is the acoustic side of an elastic-acoustic interface
-                    # locationFlag==2 is an ordinary free surface boundary condition
                     # https://seissol.readthedocs.io/en/latest/free-surface-output.html?#variables
-                    if abs(ctx.locationFlag[simp_id]-1.0) < 1e-4 || abs(ctx.locationFlag[simp_id]-2.0) < 1e-4
+                    if abs(ctx.locationFlag[simp_id]-1.0) < 1e-4
                         l_bin_ids[simp_id] = ctx.n_threads * 2 + 1 # Unused bin, will be ignored later
                         n_excluded_z_range += 1
                         continue

--- a/src/rasterizer/rasterization.jl
+++ b/src/rasterizer/rasterization.jl
@@ -341,8 +341,9 @@ module Rasterization
                     is_bath = is_bathy(m3n_simp_points, ctx.water_height)
 
                     # locationFlag==1 is the acoustic side of an elastic-acoustic interface
+                    # locationFlag==2 is an ordinary free surface boundary condition
                     # https://seissol.readthedocs.io/en/latest/free-surface-output.html?#variables
-                    if abs(ctx.locationFlag[simp_id]-1.0) < 1e-4
+                    if abs(ctx.locationFlag[simp_id]-1.0) < 1e-4 || abs(ctx.locationFlag[simp_id]-2.0) < 1e-4
                         l_bin_ids[simp_id] = ctx.n_threads * 2 + 1 # Unused bin, will be ignored later
                         n_excluded_z_range += 1
                         continue


### PR DESCRIPTION
I think I fixed errors in the Kajiura filter FFT implementation (in particular the fixed depth has to be given as a parameter and sigma must be computed with this depth, not with h_max).
I've also added an implementation without FFT allowing variable depths, which is actually not that slow.

The figure shows eta_diff at 16s with:
FFT (depth=1000m), FFT (depth 100m), non fft:
![image](https://user-images.githubusercontent.com/13536910/167164371-a16ffb51-c619-4fc6-89cd-3e5019ff9778.png)

See the thesis of Max for reference.